### PR TITLE
Add artifact creation using NFC reader

### DIFF
--- a/src/app/components/artifact-create/artifact-create.component.html
+++ b/src/app/components/artifact-create/artifact-create.component.html
@@ -3,9 +3,15 @@
 	<div>
 		<form [formGroup]="artifactForm" (ngSubmit)="onFormSubmit()">
 			<label><span>Catalog ID</span><span class="required">*</span></label>
-			<input type="text" formControlName="catalog_id" trim="blur" />
+			<input
+				type="text"
+				formControlName="catalog_id"
+				trim="blur"
+				(keypress)="onLookupCatalogId($event)"
+				autofocus
+			/>
 			<label><span>Artifact name</span><span class="required">*</span></label>
-			<input type="text" formControlName="name" trim="blur" />
+			<input #nameInput type="text" formControlName="name" trim="blur" />
 			<label><span>Artifact origin</span><span class="required">*</span></label>
 			<!-- <input type="text" formControlName="type" trim="blur" /> -->
 			<ng-select

--- a/src/app/components/artifact-create/artifact-create.component.scss
+++ b/src/app/components/artifact-create/artifact-create.component.scss
@@ -39,4 +39,9 @@ form {
 		font-size: 1.5em;
 		width: 600px;
 	}
+
+	input:disabled {
+		background-color: #151518;
+		color: #dfdfdf;
+	}
 }

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -1,0 +1,7 @@
+export function replaceAll(
+	str: string,
+	search: string,
+	replace: string
+): string {
+	return str.split(search).join(replace);
+}


### PR DESCRIPTION
If a NFC UID is read when creating an artifact, lookup the matching artifact catalog id, so that when the players take samples of the artifact later using HANSCA, we know which artifact should receive the automated test results.